### PR TITLE
Fix build-cos.sh

### DIFF
--- a/build-cos.sh
+++ b/build-cos.sh
@@ -69,7 +69,6 @@ if [ "$ARCH" != "64" ]; then
 fi
 
 # Set up paths
-cd $(dirname $0)
 DIR_ROOT=$(pwd)
 DIR_OUT=$(readlink $DIR_ROOT/out)
 [ -z "$DIR_OUT" ] && DIR_OUT="$DIR_ROOT/out"


### PR DESCRIPTION
When this script is used by SSH, dirname causes an error, and the ssh session is terminated, but by removing the line from dirname (which is unnecessary) the script works normally by ssh.