### PR TITLE
cos: overlays: Replace user_icon_1 color with color HEX

### DIFF
--- a/overlay/common/frameworks/base/core/res/res/values/colors.xml
+++ b/overlay/common/frameworks/base/core/res/res/values/colors.xml
@@ -16,7 +16,7 @@
     <color name="secondary_device_default_settings">#ff3a3a3a</color>
     <color name="system_error">#ffea4335</color>
     <color name="tertiary_device_default_settings">#ff616161</color>
-    <color name="user_icon_1">@android:color/accessibility_focus_highlight</color>
+    <color name="user_icon_1">#ff5e97f6</color>
     <color name="user_icon_2">#ff5c6bc0</color>
     <color name="user_icon_3">#ff26a69a</color>
     <color name="user_icon_4">#ffec407a</color>


### PR DESCRIPTION
vendor/cos/overlay/common/frameworks/base/core/res/res/values/colors.xml:19: error: resource android:color/accessibility_focus_highlight is private.
error: failed linking references.

Signed-off-by: Ali Hasan <ahb7671@gmail.com>